### PR TITLE
[PDI-10371] Mongo DB Output: Leaving "Write concern (w option)" blank sh...

### DIFF
--- a/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutput.java
+++ b/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutput.java
@@ -311,7 +311,7 @@ public class MongoDbOutput extends BaseStep implements StepInterface {
       }
     }
 
-    if ((retrys > 5 || isStopped()) && lastEx != null) {
+    if ((retrys > m_writeRetries || isStopped()) && lastEx != null) {
       throw new KettleException(lastEx);
     }
   }
@@ -337,7 +337,7 @@ public class MongoDbOutput extends BaseStep implements StepInterface {
       } catch (MongoException me) {
         lastEx = me;
         retrys++;
-        if (retrys <= 5) {
+        if (retrys <= m_writeRetries) {
           logError(BaseMessages.getString(PKG,
               "MongoDbOutput.Messages.Error.ErrorWritingToMongo", //$NON-NLS-1$
               me.toString()));
@@ -364,7 +364,7 @@ public class MongoDbOutput extends BaseStep implements StepInterface {
       }
     }
 
-    if ((retrys > 5 || isStopped()) && lastEx != null) {
+    if ((retrys > m_writeRetries || isStopped()) && lastEx != null) {
       throw new KettleException(lastEx);
     }
 


### PR DESCRIPTION
...ould default to write concern 1, but actually defaults to 0. Limit for throwing an exception when number of retries gets exceeded was hardcoded instead of using the user-specified value.
