### PR TITLE
Implemented support for Kerberos when authenticated via kinit

### DIFF
--- a/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutput.java
+++ b/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutput.java
@@ -23,6 +23,8 @@
 package org.pentaho.di.trans.steps.mongodboutput;
 
 import java.net.UnknownHostException;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +40,8 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
+import org.pentaho.mongo.AuthContext;
+import org.pentaho.mongo.MongoUtils;
 
 import com.mongodb.CommandResult;
 import com.mongodb.DBObject;
@@ -78,186 +82,202 @@ public class MongoDbOutput extends BaseStep implements StepInterface {
   @Override
   public boolean processRow(StepMetaInterface smi, StepDataInterface sdi)
       throws KettleException {
+    AuthContext context = MongoUtils.createAuthContext(m_meta, this);
+    try {
+      return /* allow autoboxing */ context.doAs(new PrivilegedExceptionAction<Boolean>() {
 
-    Object[] row = getRow();
+        @Override
+        public Boolean run() throws KettleException {
 
-    if (row == null) {
-      // no more output
-
-      // check any remaining buffered objects
-      if (m_batch != null && m_batch.size() > 0) {
-        doBatch();
-      }
-
-      // INDEXING - http://www.mongodb.org/display/DOCS/Indexes
-      // Indexing is computationally expensive - it needs to be
-      // done after all data is inserted and done in the BACKGROUND.
-
-      // UNIQUE indexes (prevent duplicates on the
-      // keys in the index) and SPARSE indexes (don't index docs that
-      // don't have the key field) - current limitation is that SPARSE
-      // indexes can only have a single field
-
-      List<MongoDbOutputMeta.MongoIndex> indexes = m_meta.getMongoIndexes();
-      if (indexes != null && indexes.size() > 0) {
-        logBasic(BaseMessages.getString(PKG,
-            "MongoDbOutput.Messages.ApplyingIndexOpps")); //$NON-NLS-1$
-        m_data.applyIndexes(indexes, log, m_meta.getTruncate());
-      }
-
-      disconnect();
-      setOutputDone();
-      return false;
-    }
-
-    if (first) {
-      first = false;
-
-      m_batchInsertSize = 100;
-
-      String batchInsert = environmentSubstitute(m_meta.getBatchInsertSize());
-      if (!Const.isEmpty(batchInsert)) {
-        m_batchInsertSize = Integer.parseInt(batchInsert);
-      }
-      m_batch = new ArrayList<DBObject>(m_batchInsertSize);
-
-      // output the same as the input
-      m_data.setOutputRowMeta(getInputRowMeta());
-
-      m_mongoTopLevelStructure = MongoDbOutputData.checkTopLevelConsistency(
-          m_meta.m_mongoFields, this);
-      // scan for top-level JSON document insert and validate
-      // field specification in this case.
-      m_data.m_hasTopLevelJSONDocInsert = MongoDbOutputData
-          .scanForInsertTopLevelJSONDoc(m_meta.m_mongoFields);
-
-      if (m_mongoTopLevelStructure == MongoDbOutputData.MongoTopLevel.INCONSISTENT) {
-        throw new KettleException(BaseMessages.getString(PKG,
-            "MongoDbOutput.Messages.Error.InconsistentMongoTopLevel")); //$NON-NLS-1$
-      }
-
-      // first check our incoming fields against our meta data for fields to
-      // insert
-      RowMetaInterface rmi = getInputRowMeta();
-      List<MongoDbOutputMeta.MongoField> mongoFields = m_meta.getMongoFields();
-      List<String> notToBeInserted = new ArrayList<String>();
-
-      for (int i = 0; i < rmi.size(); i++) {
-        ValueMetaInterface vm = rmi.getValueMeta(i);
-        boolean ok = false;
-        for (MongoDbOutputMeta.MongoField field : mongoFields) {
-          String mongoMatch = environmentSubstitute(field.m_incomingFieldName);
-          if (vm.getName().equals(mongoMatch)) {
-            ok = true;
-            break;
-          }
-        }
-
-        if (!ok) {
-          notToBeInserted.add(vm.getName());
-        }
-      }
-
-      if (notToBeInserted.size() == rmi.size()) {
-        throw new KettleException(BaseMessages.getString(PKG,
-            "MongoDbOutput.Messages.Error.NotInsertingAnyFields")); //$NON-NLS-1$
-      }
-
-      if (notToBeInserted.size() > 0) {
-        StringBuffer b = new StringBuffer();
-        for (String s : notToBeInserted) {
-          b.append(s).append(" "); //$NON-NLS-1$
-        }
-
-        logBasic(BaseMessages.getString(PKG,
-            "MongoDbOutput.Messages.FieldsNotToBeInserted"), b.toString()); //$NON-NLS-1$
-      }
-
-      // copy and initialize mongo fields
-      m_data.setMongoFields(m_meta.getMongoFields());
-      m_data.init(this);
-
-      // check truncate
-      if (m_meta.getTruncate()) {
-        try {
-          logBasic(BaseMessages.getString(PKG,
-              "MongoDbOutput.Messages.TruncatingCollection")); //$NON-NLS-1$
-          m_data.getCollection().drop();
-
-          // re-establish the collection
-          String collection = environmentSubstitute(m_meta.getCollection());
-          m_data.createCollection(collection);
-          m_data.setCollection(m_data.getDB().getCollection(collection));
-        } catch (Exception m) {
-          disconnect();
-          throw new KettleException(m.getMessage(), m);
-        }
-      }
-    }
-
-    if (!isStopped()) {
-
-      if (m_meta.getUpsert()) {
-        DBObject updateQuery = m_data.getQueryObject(m_data.m_userFields,
-            getInputRowMeta(), row, this, m_mongoTopLevelStructure);
-
-        if (log.isDebug()) {
-          logDebug(BaseMessages.getString(PKG,
-              "MongoDbOutput.Messages.Debug.QueryForUpsert", updateQuery)); //$NON-NLS-1$
-        }
-
-        if (updateQuery != null) {
-          // i.e. we have some non-null incoming query field values
-          DBObject insertUpdate = null;
-
-          // get the record to update the match with
-          if (!m_meta.getModifierUpdate()) {
-            // complete record replace or insert
-
-            insertUpdate = MongoDbOutputData.kettleRowToMongo(
-                m_data.m_userFields, getInputRowMeta(), row, this,
-                m_mongoTopLevelStructure, m_data.m_hasTopLevelJSONDocInsert);
-            if (log.isDebug()) {
-              logDebug(BaseMessages.getString(PKG,
-                  "MongoDbOutput.Messages.Debug.InsertUpsertObject", //$NON-NLS-1$
-                  insertUpdate));
+          Object[] row = getRow();
+      
+          if (row == null) {
+            // no more output
+      
+            // check any remaining buffered objects
+            if (m_batch != null && m_batch.size() > 0) {
+              doBatch();
             }
-
-          } else {
-
-            // specific field update or insert
-            insertUpdate = m_data.getModifierUpdateObject(m_data.m_userFields,
-                getInputRowMeta(), row, this, m_mongoTopLevelStructure);
-            if (log.isDebug()) {
-              logDebug(BaseMessages.getString(PKG,
-                  "MongoDbOutput.Messages.Debug.ModifierUpdateObject", //$NON-NLS-1$
-                  insertUpdate));
+      
+            // INDEXING - http://www.mongodb.org/display/DOCS/Indexes
+            // Indexing is computationally expensive - it needs to be
+            // done after all data is inserted and done in the BACKGROUND.
+      
+            // UNIQUE indexes (prevent duplicates on the
+            // keys in the index) and SPARSE indexes (don't index docs that
+            // don't have the key field) - current limitation is that SPARSE
+            // indexes can only have a single field
+      
+            List<MongoDbOutputMeta.MongoIndex> indexes = m_meta.getMongoIndexes();
+            if (indexes != null && indexes.size() > 0) {
+              logBasic(BaseMessages.getString(PKG,
+                  "MongoDbOutput.Messages.ApplyingIndexOpps")); //$NON-NLS-1$
+              m_data.applyIndexes(indexes, log, m_meta.getTruncate());
+            }
+      
+            disconnect();
+            setOutputDone();
+            return false;
+          }
+      
+          if (first) {
+            first = false;
+      
+            m_batchInsertSize = 100;
+      
+            String batchInsert = environmentSubstitute(m_meta.getBatchInsertSize());
+            if (!Const.isEmpty(batchInsert)) {
+              m_batchInsertSize = Integer.parseInt(batchInsert);
+            }
+            m_batch = new ArrayList<DBObject>(m_batchInsertSize);
+      
+            // output the same as the input
+            m_data.setOutputRowMeta(getInputRowMeta());
+      
+            m_mongoTopLevelStructure = MongoDbOutputData.checkTopLevelConsistency(
+                m_meta.m_mongoFields, MongoDbOutput.this);
+            // scan for top-level JSON document insert and validate
+            // field specification in this case.
+            m_data.m_hasTopLevelJSONDocInsert = MongoDbOutputData
+                .scanForInsertTopLevelJSONDoc(m_meta.m_mongoFields);
+      
+            if (m_mongoTopLevelStructure == MongoDbOutputData.MongoTopLevel.INCONSISTENT) {
+              throw new KettleException(BaseMessages.getString(PKG,
+                  "MongoDbOutput.Messages.Error.InconsistentMongoTopLevel")); //$NON-NLS-1$
+            }
+      
+            // first check our incoming fields against our meta data for fields to
+            // insert
+            RowMetaInterface rmi = getInputRowMeta();
+            List<MongoDbOutputMeta.MongoField> mongoFields = m_meta.getMongoFields();
+            List<String> notToBeInserted = new ArrayList<String>();
+      
+            for (int i = 0; i < rmi.size(); i++) {
+              ValueMetaInterface vm = rmi.getValueMeta(i);
+              boolean ok = false;
+              for (MongoDbOutputMeta.MongoField field : mongoFields) {
+                String mongoMatch = environmentSubstitute(field.m_incomingFieldName);
+                if (vm.getName().equals(mongoMatch)) {
+                  ok = true;
+                  break;
+                }
+              }
+      
+              if (!ok) {
+                notToBeInserted.add(vm.getName());
+              }
+            }
+      
+            if (notToBeInserted.size() == rmi.size()) {
+              throw new KettleException(BaseMessages.getString(PKG,
+                  "MongoDbOutput.Messages.Error.NotInsertingAnyFields")); //$NON-NLS-1$
+            }
+      
+            if (notToBeInserted.size() > 0) {
+              StringBuffer b = new StringBuffer();
+              for (String s : notToBeInserted) {
+                b.append(s).append(" "); //$NON-NLS-1$
+              }
+      
+              logBasic(BaseMessages.getString(PKG,
+                  "MongoDbOutput.Messages.FieldsNotToBeInserted"), b.toString()); //$NON-NLS-1$
+            }
+      
+            // copy and initialize mongo fields
+            m_data.setMongoFields(m_meta.getMongoFields());
+            m_data.init(MongoDbOutput.this);
+      
+            // check truncate
+            if (m_meta.getTruncate()) {
+              try {
+                logBasic(BaseMessages.getString(PKG,
+                    "MongoDbOutput.Messages.TruncatingCollection")); //$NON-NLS-1$
+                m_data.getCollection().drop();
+      
+                // re-establish the collection
+                String collection = environmentSubstitute(m_meta.getCollection());
+                m_data.createCollection(collection);
+                m_data.setCollection(m_data.getDB().getCollection(collection));
+              } catch (Exception m) {
+                disconnect();
+                throw new KettleException(m.getMessage(), m);
+              }
             }
           }
-
-          if (insertUpdate != null) {
-            commitUpsert(updateQuery, insertUpdate);
+      
+          if (!isStopped()) {
+      
+            if (m_meta.getUpsert()) {
+              DBObject updateQuery = m_data.getQueryObject(m_data.m_userFields,
+                  getInputRowMeta(), row, MongoDbOutput.this, m_mongoTopLevelStructure);
+      
+              if (log.isDebug()) {
+                logDebug(BaseMessages.getString(PKG,
+                    "MongoDbOutput.Messages.Debug.QueryForUpsert", updateQuery)); //$NON-NLS-1$
+              }
+      
+              if (updateQuery != null) {
+                // i.e. we have some non-null incoming query field values
+                DBObject insertUpdate = null;
+      
+                // get the record to update the match with
+                if (!m_meta.getModifierUpdate()) {
+                  // complete record replace or insert
+      
+                  insertUpdate = MongoDbOutputData.kettleRowToMongo(
+                      m_data.m_userFields, getInputRowMeta(), row, MongoDbOutput.this,
+                      m_mongoTopLevelStructure, m_data.m_hasTopLevelJSONDocInsert);
+                  if (log.isDebug()) {
+                    logDebug(BaseMessages.getString(PKG,
+                        "MongoDbOutput.Messages.Debug.InsertUpsertObject", //$NON-NLS-1$
+                        insertUpdate));
+                  }
+      
+                } else {
+      
+                  // specific field update or insert
+                  insertUpdate = m_data.getModifierUpdateObject(m_data.m_userFields,
+                      getInputRowMeta(), row, MongoDbOutput.this, m_mongoTopLevelStructure);
+                  if (log.isDebug()) {
+                    logDebug(BaseMessages.getString(PKG,
+                        "MongoDbOutput.Messages.Debug.ModifierUpdateObject", //$NON-NLS-1$
+                        insertUpdate));
+                  }
+                }
+      
+                if (insertUpdate != null) {
+                  commitUpsert(updateQuery, insertUpdate);
+                }
+              }
+            } else {
+              // straight insert
+      
+              DBObject mongoInsert = MongoDbOutputData.kettleRowToMongo(
+                  m_data.m_userFields, getInputRowMeta(), row, MongoDbOutput.this,
+                  m_mongoTopLevelStructure, m_data.m_hasTopLevelJSONDocInsert);
+      
+              if (mongoInsert != null) {
+                m_batch.add(mongoInsert);
+              }
+              if (m_batch.size() == m_batchInsertSize) {
+                logDetailed(BaseMessages.getString(PKG,
+                    "MongoDbOutput.Messages.CommitingABatch")); //$NON-NLS-1$
+                doBatch();
+              }
+            }
           }
+      
+          return true;
         }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable cause = e.getException();
+      if (cause instanceof KettleException) {
+        throw (KettleException) cause;
       } else {
-        // straight insert
-
-        DBObject mongoInsert = MongoDbOutputData.kettleRowToMongo(
-            m_data.m_userFields, getInputRowMeta(), row, this,
-            m_mongoTopLevelStructure, m_data.m_hasTopLevelJSONDocInsert);
-
-        if (mongoInsert != null) {
-          m_batch.add(mongoInsert);
-        }
-        if (m_batch.size() == m_batchInsertSize) {
-          logDetailed(BaseMessages.getString(PKG,
-              "MongoDbOutput.Messages.CommitingABatch")); //$NON-NLS-1$
-          doBatch();
-        }
+        throw new KettleException("Unexpected error", e.getException());
       }
     }
-
-    return true;
   }
 
   protected void commitUpsert(DBObject updateQuery, DBObject insertUpdate)

--- a/src/org/pentaho/mongo/AuthContext.java
+++ b/src/org/pentaho/mongo/AuthContext.java
@@ -1,0 +1,78 @@
+package org.pentaho.mongo;
+
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginContext;
+
+/**
+ * A context for executing authorized actions on behalf of an authenticated user
+ * via a {@link LoginContext}.
+ * 
+ * @author Jordan Ganoff <jganoff@pentaho.com>
+ * 
+ */
+public class AuthContext {
+  private LoginContext login;
+
+  /**
+   * Create a context for the given login. If the login is null all operations
+   * will be done as the current user.
+   * 
+   * TODO Prevent null login contexts and create login contexts for the current
+   * OS user instead. This will keep the implementation cleaner.
+   * 
+   * @param login
+   */
+  public AuthContext(LoginContext login) {
+    this.login = login;
+  }
+
+  /**
+   * Execute an action on behalf of the login used to create this context. If no
+   * user is explicitly authenticated the action will be executed as the current
+   * user.
+   * 
+   * @param action
+   *          The action to execute
+   * @return The return value of the action
+   */
+  public <T> T doAs(PrivilegedAction<T> action) {
+    if (login == null) {
+      // If a user is not explicitly authenticated directly execute the action
+      return action.run();
+    } else {
+      return Subject.doAs(login.getSubject(), action);
+    }
+  }
+
+  /**
+   * Execute an action on behalf of the login used to create this context. If no
+   * user is explicitly authenticated the action will be executed as the current
+   * user.
+   * 
+   * @param action
+   *          The action to execute
+   * @return The return value of the action
+   * @throws PrivilegedActionException
+   *           If an exception occurs while executing the action. The cause of
+   *           the exception will be provided in
+   *           {@link PrivilegedActionException#getCause()}.
+   */
+  public <T> T doAs(PrivilegedExceptionAction<T> action) throws PrivilegedActionException {
+    if (login == null) {
+      // If a user is not explicitly authenticated directly execute the action
+      try {
+        return action.run();
+      } catch (Exception ex) {
+        // Wrap any exceptions throw in a PrivilegedActionException just as
+        // would be thrown when executed via Subject.doAs(..)
+        throw new PrivilegedActionException(ex);
+      }
+    } else {
+      return Subject.doAs(login.getSubject(), action);
+    }
+  }
+}

--- a/src/org/pentaho/mongo/KerberosUtil.java
+++ b/src/org/pentaho/mongo/KerberosUtil.java
@@ -1,0 +1,76 @@
+package org.pentaho.mongo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import com.sun.security.auth.module.Krb5LoginModule;
+
+/**
+ * A collection of utilities for working with Kerberos.
+ * 
+ * Note: This specifically does not support IBM VMs and must be modified to do
+ * so: 1) LoginModule name differs, 2) Configuration defaults differ for ticket
+ * cache, keytab, and others.
+ * 
+ * @author Jordan Ganoff <jganoff@pentaho.com>
+ */
+public class KerberosUtil {
+  /**
+   * The application name to use when creating login contexts.
+   */
+  private static final String KERBEROS_APP_NAME = "pentaho";
+
+  private static final Map<String, String> LOGIN_CONFIG_KERBEROS;
+  static {
+    LOGIN_CONFIG_KERBEROS = new HashMap<String, String>();
+    // Never prompt for passwords
+    LOGIN_CONFIG_KERBEROS.put("doNotPrompt", Boolean.TRUE.toString());
+    LOGIN_CONFIG_KERBEROS.put("useTicketCache", Boolean.TRUE.toString());
+    // Attempt to renew tickets
+    LOGIN_CONFIG_KERBEROS.put("renewTGT", Boolean.TRUE.toString());
+    // Set the ticket cache if it was defined externally
+    String ticketCache = System.getenv("KRB5CCNAME");
+    if (ticketCache != null) {
+      LOGIN_CONFIG_KERBEROS.put("ticketCache", ticketCache);
+    }
+  }
+
+  // The Login Configuration entry to use for authenticating with Kerberos
+  private static final AppConfigurationEntry CONFIG_ENTRY_PENTAHO_KERBEROS = new AppConfigurationEntry(Krb5LoginModule.class.getName(),
+      LoginModuleControlFlag.REQUIRED, LOGIN_CONFIG_KERBEROS);
+
+  private static final AppConfigurationEntry[] CONFIG_ENTRIES = new AppConfigurationEntry[] { CONFIG_ENTRY_PENTAHO_KERBEROS };
+
+  /**
+   * A Login Configuration that is configured statically within this class.
+   */
+  private static class StaticConfiguration extends Configuration {
+    @Override
+    public AppConfigurationEntry[] getAppConfigurationEntry(String ignored) {
+      return CONFIG_ENTRIES;
+    }
+  }
+
+  /**
+   * Login as the provided principal. This assumes the user has already
+   * authenticated with kerberos and a TGT exists in the cache.
+   * 
+   * @param principal
+   *          Principal to login in as.
+   * @return
+   * @throws LoginException
+   */
+  public LoginContext loginAs(String principal) throws LoginException {
+    Subject subject = new Subject();
+    LoginContext lc = new LoginContext(KERBEROS_APP_NAME, subject, null, new StaticConfiguration());
+    lc.login();
+    return lc;
+  }
+}


### PR DESCRIPTION
In order to authenticate with MongoDB via Kerberos you must execute operations within a privileged action. This is the first stab at allowing a user previously authenticated with Kerberos to communicate with a secure MongoDB instance. All MongoDB Input and Output step operations are supported in addition to the XUL Input dialog used in Reporting. This does not add Kerberos support to the XUL dialog; however, it is tested and continues to function with the changes. Most of the code change is refactoring existing logic to be executed within `PrivilegedExceptionAction`s. I tried to change as little as possible.

This change also introduces `org.pentaho.mongo.AuthContext`. This is loosely modeled after Hadoop's `UserGroupInformation` and allows a developer to easily execute code on behalf of an authenticated `LoginContext`. `MongoUtils.createAuthContext(..)` can be used to obtain one from a MongoDB Input or Output meta.

These changes need to be elaborated on to support keytab usage for headless environments. See `org.pentaho.mongo.KerberosUtil` for how I've wired up the LoginContext/Configuration programmatically so no additional work is required by the user to set up PDI or Reporting to work with Kerberos.

Note: There is an unfortunate amount of code duplication due to the separate classes for input and output metadata. It would be best to consolidate these - at least behind a common interface so a lot of the code duplication can be avoided in the future.
