### PR TITLE
More Kerberos goodies (keytab support + external config)

### DIFF
--- a/src/org/pentaho/mongo/KerberosUtil.java
+++ b/src/org/pentaho/mongo/KerberosUtil.java
@@ -27,50 +27,185 @@ public class KerberosUtil {
    */
   private static final String KERBEROS_APP_NAME = "pentaho";
 
-  private static final Map<String, String> LOGIN_CONFIG_KERBEROS;
+  /**
+   * The environment property to set to enable JAAS debugging for the
+   * LoginConfiguration created by this utility.
+   */
+  private static final String PENTAHO_JAAS_DEBUG = "PENTAHO_JAAS_DEBUG";
+
+  /**
+   * Base properties to be inherited by all other LOGIN_CONFIG* configuration
+   * maps.
+   */
+  private static final Map<String, String> LOGIN_CONFIG_BASE;
   static {
-    LOGIN_CONFIG_KERBEROS = new HashMap<String, String>();
+    LOGIN_CONFIG_BASE = new HashMap<String, String>();
+    // Enable JAAS debug if PENTAHO_JAAS_DEBUG is set
+    if (Boolean.parseBoolean(System.getenv(PENTAHO_JAAS_DEBUG))) {
+      LOGIN_CONFIG_BASE.put("debug", Boolean.TRUE.toString());
+    }
+  }
+
+  /**
+   * Login Configuration options for KERBEROS_USER mode.
+   */
+  private static final Map<String, String> LOGIN_CONFIG_OPTS_KERBEROS_USER;
+  static {
+    LOGIN_CONFIG_OPTS_KERBEROS_USER = new HashMap<String, String>(LOGIN_CONFIG_BASE);
     // Never prompt for passwords
-    LOGIN_CONFIG_KERBEROS.put("doNotPrompt", Boolean.TRUE.toString());
-    LOGIN_CONFIG_KERBEROS.put("useTicketCache", Boolean.TRUE.toString());
+    LOGIN_CONFIG_OPTS_KERBEROS_USER.put("doNotPrompt", Boolean.TRUE.toString());
+    LOGIN_CONFIG_OPTS_KERBEROS_USER.put("useTicketCache", Boolean.TRUE.toString());
     // Attempt to renew tickets
-    LOGIN_CONFIG_KERBEROS.put("renewTGT", Boolean.TRUE.toString());
+    LOGIN_CONFIG_OPTS_KERBEROS_USER.put("renewTGT", Boolean.TRUE.toString());
     // Set the ticket cache if it was defined externally
     String ticketCache = System.getenv("KRB5CCNAME");
     if (ticketCache != null) {
-      LOGIN_CONFIG_KERBEROS.put("ticketCache", ticketCache);
+      LOGIN_CONFIG_OPTS_KERBEROS_USER.put("ticketCache", ticketCache);
     }
   }
 
-  // The Login Configuration entry to use for authenticating with Kerberos
-  private static final AppConfigurationEntry CONFIG_ENTRY_PENTAHO_KERBEROS = new AppConfigurationEntry(Krb5LoginModule.class.getName(),
-      LoginModuleControlFlag.REQUIRED, LOGIN_CONFIG_KERBEROS);
-
-  private static final AppConfigurationEntry[] CONFIG_ENTRIES = new AppConfigurationEntry[] { CONFIG_ENTRY_PENTAHO_KERBEROS };
+  /**
+   * Login Configuration options for KERBEROS_KEYTAB mode.
+   */
+  private static final Map<String, String> LOGIN_CONFIG_OPTS_KERBEROS_KEYTAB;
+  static {
+    LOGIN_CONFIG_OPTS_KERBEROS_KEYTAB = new HashMap<String, String>(LOGIN_CONFIG_BASE);
+    // Never prompt for passwords
+    LOGIN_CONFIG_OPTS_KERBEROS_KEYTAB.put("doNotPrompt", Boolean.TRUE.toString());
+    // Use a keytab file
+    LOGIN_CONFIG_OPTS_KERBEROS_KEYTAB.put("useKeyTab", Boolean.TRUE.toString());
+    LOGIN_CONFIG_OPTS_KERBEROS_KEYTAB.put("storeKey", Boolean.TRUE.toString());
+    // Refresh KRB5 config before logging in
+    LOGIN_CONFIG_OPTS_KERBEROS_KEYTAB.put("refreshKrb5Config", Boolean.TRUE.toString());
+  }
 
   /**
-   * A Login Configuration that is configured statically within this class.
+   * The Login Configuration entry to use for authenticating with Kerberos.
    */
-  private static class StaticConfiguration extends Configuration {
+  private static final AppConfigurationEntry CONFIG_ENTRY_PENTAHO_KERBEROS_USER = new AppConfigurationEntry(
+      Krb5LoginModule.class.getName(), LoginModuleControlFlag.REQUIRED, LOGIN_CONFIG_OPTS_KERBEROS_USER);
+
+  /**
+   * Static configuration to use when KERBEROS_USER mode is enabled.
+   */
+  private static final AppConfigurationEntry[] CONFIG_ENTRIES_KERBEROS_USER = new AppConfigurationEntry[] { CONFIG_ENTRY_PENTAHO_KERBEROS_USER };
+
+  /**
+   * A Login Configuration that is pre-configured based on our static
+   * configuration.
+   */
+  private static class PentahoLoginConfiguration extends Configuration {
+    private AppConfigurationEntry[] entries;
+
+    public PentahoLoginConfiguration(AppConfigurationEntry[] entries) {
+      if (entries == null) {
+        throw new NullPointerException("AppConfigurationEntry[] is required");
+      }
+      this.entries = entries;
+    }
+
     @Override
     public AppConfigurationEntry[] getAppConfigurationEntry(String ignored) {
-      return CONFIG_ENTRIES;
+      return entries;
     }
   }
 
   /**
-   * Login as the provided principal. This assumes the user has already
+   * Defines the types of Kerberos authentication modes we support.
+   */
+  public static enum JaasAuthenticationMode {
+    /**
+     * User has pre-authenticated with Kerberos (likely via kinit) and has
+     * launched this process within that authenticated environment.
+     */
+    KERBEROS_USER,
+
+    /**
+     * A keytab file must be used to authenticate.
+     */
+    KERBEROS_KEYTAB,
+
+    /**
+     * A default authentication mode to bypass our static configuration. This is
+     * to be used with an externally configured JAAS Configuration file.
+     */
+    EXTERNAL;
+  };
+
+  /**
+   * Log in as the provided principal. If a keytab file is specified in the
+   * environment property "PENTAHO_JAAS_KEYTAB_FILE", it will be used during
+   * authentication.
+   * 
+   * @see #loginAs(String, String) loginAs(principal,
+   *      env("PENTAHO_KEYTAB_FILE"))
+   */
+  public static LoginContext loginAs(String principal) throws LoginException {
+    return loginAs(JaasAuthenticationMode.KERBEROS_USER, principal, null);
+  }
+
+  /**
+   * Log in as the provided principal. This assumes the user has already
    * authenticated with kerberos and a TGT exists in the cache.
    * 
    * @param principal
    *          Principal to login in as.
-   * @return
+   * @param keytabFile
+   * @return The context for the logged in principal.
    * @throws LoginException
+   *           Error encountered while logging in.
    */
-  public LoginContext loginAs(String principal) throws LoginException {
-    Subject subject = new Subject();
-    LoginContext lc = new LoginContext(KERBEROS_APP_NAME, subject, null, new StaticConfiguration());
+  public static LoginContext loginAs(JaasAuthenticationMode authMode, String principal, String keytabFile) throws LoginException {
+    LoginContext lc;
+    Subject subject;
+    switch (authMode) {
+    case EXTERNAL:
+      // Use the default JAAS configuration by only supplying the app name
+      lc = new LoginContext(KERBEROS_APP_NAME);
+    case KERBEROS_USER:
+      subject = new Subject();
+      lc = new LoginContext(KERBEROS_APP_NAME, subject, null, new PentahoLoginConfiguration(CONFIG_ENTRIES_KERBEROS_USER));
+      break;
+    case KERBEROS_KEYTAB:
+      lc = createLoginContextWithKeytab(principal, keytabFile);
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported authentication mode: " + authMode);
+    }
+    // Perform the login
     lc.login();
     return lc;
+  }
+
+  /**
+   * Creates a {@link LoginContext} configured to authenticate with the provided
+   * credentials.
+   * 
+   * @param principal
+   *          Principal to authenticate as.
+   * @param keytabFile
+   *          Keytab file with credentials to authenticate as the given
+   *          principal.
+   * @return A login context configured to authenticate as the provided
+   *         principal via a keytab.
+   * @throws LoginException
+   *           Error creating login context.
+   */
+  private static LoginContext createLoginContextWithKeytab(String principal, String keytabFile) throws LoginException {
+    if (keytabFile == null) {
+      throw new IllegalArgumentException("A keytab file is required to authenticate with Kerberos via keytab");
+    }
+
+    // Extend the default keytab config properties and set the necessary
+    // overrides for this invocation
+    Map<String, String> keytabConfig = new HashMap<String, String>(LOGIN_CONFIG_OPTS_KERBEROS_KEYTAB);
+    keytabConfig.put("keyTab", keytabFile);
+    keytabConfig.put("principal", principal);
+
+    // Create the configuration and from them, a new login context
+    AppConfigurationEntry config = new AppConfigurationEntry(Krb5LoginModule.class.getName(), LoginModuleControlFlag.REQUIRED, keytabConfig);
+    AppConfigurationEntry[] configEntries = new AppConfigurationEntry[] { config };
+    Subject subject = new Subject();
+    return new LoginContext(KERBEROS_APP_NAME, subject, null, new PentahoLoginConfiguration(configEntries));
   }
 }

--- a/src/org/pentaho/mongo/KettleKerberosHelper.java
+++ b/src/org/pentaho/mongo/KettleKerberosHelper.java
@@ -1,0 +1,87 @@
+package org.pentaho.mongo;
+
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.mongo.KerberosUtil.JaasAuthenticationMode;
+
+/**
+ * A collection of helper functions to make working with Kettle and Kerberos
+ * easier.
+ * 
+ * @author Jordan Ganoff <jganoff@pentaho.com>
+ * 
+ */
+public class KettleKerberosHelper {
+  /**
+   * The variable name that may specify the authentication mode to use when
+   * creating a JAAS LoginContext. See {@link JaasAuthenticationMode} for
+   * possible values.
+   */
+  private static final String PENTAHO_JAAS_AUTH_MODE = "PENTAHO_JAAS_AUTH_MODE";
+
+  /**
+   * The variable name that may specify the location of the keytab file to use
+   * when authenticating with "KERBEROS_KEYTAB" mode.
+   */
+  private static final String PENTAHO_JAAS_KEYTAB_FILE = "PENTAHO_JAAS_KEYTAB_FILE";
+
+  /**
+   * Determine the authentication mode to use based on the property
+   * "PENTAHO_JAAS_AUTH_MODE". If not provided this defaults to
+   * {@link JaasAuthenticationMode#KERBEROS_USER}.
+   * 
+   * @param varSpace
+   *          Context to look up variable in.
+   * @return The authentication mode to use when creating JAAS
+   *         {@link LoginContext}s.
+   */
+  private static JaasAuthenticationMode lookupLoginAuthMode(VariableSpace varSpace) {
+    JaasAuthenticationMode authMode;
+    try {
+      authMode = JaasAuthenticationMode.valueOf(varSpace.getVariable(PENTAHO_JAAS_AUTH_MODE));
+    } catch (Exception ex) {
+      // Ignore and use default of USER
+      authMode = JaasAuthenticationMode.KERBEROS_USER;
+    }
+    return authMode;
+  }
+
+  /**
+   * Determine the keytab file to use based on the variable
+   * "PENTAHO_JAAS_KEYTAB_FILE". If not is set keytab authentication will not be
+   * used.
+   * 
+   * @param varSpace
+   *          Context to look up variable in.
+   * @return keytab file location if defined as the variable
+   *         "PENTAHO_JAAS_KEYTAB_FILE".
+   */
+  private static String lookupKeytabFile(VariableSpace varSpace) {
+    return varSpace.getVariable(PENTAHO_JAAS_KEYTAB_FILE);
+  }
+
+  /**
+   * Log in to Kerberos with the principal using the configuration defined in
+   * the variable space provided.
+   * 
+   * @param varSpace
+   *          Variable space to look up configuration in.
+   * @param principal
+   *          Principal to log in as.
+   * @return The context for the logged in principal.
+   * @throws KettleException
+   *           if an error occurs while logging in.
+   */
+  public static LoginContext login(VariableSpace varSpace, String principal) throws KettleException {
+    try {
+      JaasAuthenticationMode authMode = lookupLoginAuthMode(varSpace);
+      String keytabFile = lookupKeytabFile(varSpace);
+      return KerberosUtil.loginAs(authMode, principal, keytabFile);
+    } catch (LoginException ex) {
+      throw new KettleException("Unable to authenticate as '" + principal + "'", ex);
+    }
+  }
+}


### PR DESCRIPTION
This adds support for authenticating with a keytab file. I also added the ability to use an external JAAS config so settings can be entirely overwritten by providing a configuration for "pentaho".

This does not include auto-refreshing of keytab tickets. That work is left to do.

Keytab support is plumbed through via transformation properties today. The 2 properties you must set are:

`PENTAHO_JAAS_AUTH_MODE=KERBEROS_KEYTAB`
`PENTAHO_JAAS_KEYTAB_FILE=/home/user/my.keytab`

More details can be found in `KettleKerberosHelper`.
