### PR TITLE
Backport of PDI-11169 - MongoDB Output throws Null Pointer when fields are blank (5.0)

### DIFF
--- a/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputData.java
+++ b/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputData.java
@@ -1030,8 +1030,12 @@ public class MongoDbOutputData extends BaseStepData implements
    * @param vars environment variables
    * @return the top level structure
    */
-  protected static MongoTopLevel checkTopLevelConsistency(
-      List<MongoDbOutputMeta.MongoField> fieldDefs, VariableSpace vars) {
+  protected static MongoTopLevel checkTopLevelConsistency(List<MongoDbOutputMeta.MongoField> fieldDefs,
+                                                          VariableSpace vars) throws KettleException {
+
+    if ( fieldDefs == null || fieldDefs.size() == 0 ) {
+      throw new KettleException( BaseMessages.getString( PKG, "MongoDbOutput.Messages.Error.NoMongoPathsDefined" ) );
+    }
 
     int numRecords = 0;
     int numArrays = 0;

--- a/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputDialog.java
+++ b/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputDialog.java
@@ -1258,6 +1258,13 @@ public class MongoDbOutputDialog extends BaseStepDialog implements
       }
 
       return mongoFields;
+    } else {
+      // popup dialog warning that no paths have been defined
+      ShowMessageDialog smd =
+              new ShowMessageDialog( shell, SWT.ICON_WARNING | SWT.OK, BaseMessages.getString( PKG,
+                      "MongoDbOutputDialog.ErrorMessage.NoFieldPathsDefined.Title" ), BaseMessages.getString( PKG, //$NON-NLS-1$
+                      "MongoDbOutputDialog.ErrorMessage.NoFieldPathsDefined" ) ); //$NON-NLS-1$
+      smd.open();
     }
 
     return null;

--- a/src/org/pentaho/di/trans/steps/mongodboutput/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/trans/steps/mongodboutput/messages/messages_en_US.properties
@@ -115,6 +115,7 @@ MongoDbOutput.Messages.Error.ErrorWritingToMongo=An error occurred during write:
 MongoDbOutput.Messages.Message.Retry=Retrying write to mongodb in {0} seconds...
 
 MongoDbOutput.Messages.Error.MongoReported=Mongo reported: {0}
+MongoDbOutput.Messages.Error.NoMongoPathsDefined=No document field paths defined!
 MongoDbOutput.Messages.WroteBatchToServer=Wrote batch to server: {0}
 MongoDbOutput.Messages.MatchFieldJSONButIncomingValueNotString=Match field is specified as JSON but incoming Kettle value is not a String
 MongoDbOutput.Messages.CurrentBatchSize = Current batch size: {0}
@@ -135,5 +136,7 @@ MongoDbOutputDialog.ErrorMessage.UnableToGetInfoForCollection=Unable to get info
 MongoDbOutputDialog.ErrorMessage.UnableToGetInfoForCollection=No index information available for collection: {0}
 MongoDbOutputDialog.ErrorMessage.MissingConnectionDetails.Title=Missing connection details
 MongoDbOutputDialog.ErrorMessage.MissingConnectionDetails=Some connection/configuration details are missing: {0}
+MongoDbOutputDialog.ErrorMessage.NoFieldPathsDefined.Title=No field paths defined
+MongoDbOutputDialog.ErrorMessage.NoFieldPathsDefined=No field paths are defined in the Mongo document fields tab
 MongoDbOutput.Message.KerberosAuthentication=Kerberos authentication for user {0}
 MongoDbOutput.Message.NormalAuthentication=Normal authentication for user {0}

--- a/test-src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputTest.java
+++ b/test-src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputTest.java
@@ -16,6 +16,8 @@ import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.trans.steps.mongodboutput.MongoDbOutputData.MongoTopLevel;
+
 
 import com.mongodb.DBObject;
 
@@ -25,6 +27,74 @@ import com.mongodb.DBObject;
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  */
 public class MongoDbOutputTest {
+
+  @Test
+  public void testCheckTopLevelConsistencyPathsAreConsistentRecord() throws KettleException {
+    List<MongoDbOutputMeta.MongoField> paths = new ArrayList<MongoDbOutputMeta.MongoField>();
+
+    MongoDbOutputMeta.MongoField mf = new MongoDbOutputMeta.MongoField();
+    mf.m_incomingFieldName = "field1";
+    mf.m_mongoDocPath = "";
+    mf.m_useIncomingFieldNameAsMongoFieldName = true;
+    paths.add( mf );
+
+    mf = new MongoDbOutputMeta.MongoField();
+    mf.m_incomingFieldName = "field2";
+    mf.m_mongoDocPath = "";
+    mf.m_useIncomingFieldNameAsMongoFieldName = true;
+    paths.add( mf );
+
+    MongoTopLevel topLevel = MongoDbOutputData.checkTopLevelConsistency( paths, new Variables() );
+    assertTrue( topLevel == MongoTopLevel.RECORD );
+  }
+
+  @Test
+  public void testCheckTopLevelConsistencyPathsAreConsistentArray() throws KettleException {
+    List<MongoDbOutputMeta.MongoField> paths = new ArrayList<MongoDbOutputMeta.MongoField>();
+
+    MongoDbOutputMeta.MongoField mf = new MongoDbOutputMeta.MongoField();
+    mf.m_incomingFieldName = "field1";
+    mf.m_mongoDocPath = "[0]";
+    mf.m_useIncomingFieldNameAsMongoFieldName = true;
+    paths.add( mf );
+
+    mf = new MongoDbOutputMeta.MongoField();
+    mf.m_incomingFieldName = "field2";
+    mf.m_mongoDocPath = "[0]";
+    mf.m_useIncomingFieldNameAsMongoFieldName = true;
+    paths.add( mf );
+
+    MongoTopLevel topLevel = MongoDbOutputData.checkTopLevelConsistency( paths, new Variables() );
+    assertTrue( topLevel == MongoTopLevel.ARRAY );
+  }
+
+  @Test
+  public void testCheckTopLevelConsistencyPathsAreInconsistent() throws KettleException {
+    List<MongoDbOutputMeta.MongoField> paths = new ArrayList<MongoDbOutputMeta.MongoField>();
+
+    MongoDbOutputMeta.MongoField mf = new MongoDbOutputMeta.MongoField();
+    mf.m_incomingFieldName = "field1";
+    mf.m_mongoDocPath = "";
+    mf.m_useIncomingFieldNameAsMongoFieldName = true;
+    paths.add( mf );
+
+    mf = new MongoDbOutputMeta.MongoField();
+    mf.m_incomingFieldName = "field2";
+    mf.m_mongoDocPath = "[0]";
+    mf.m_useIncomingFieldNameAsMongoFieldName = true;
+    paths.add( mf );
+
+    MongoTopLevel topLevel = MongoDbOutputData.checkTopLevelConsistency( paths, new Variables() );
+
+    assertTrue( topLevel == MongoTopLevel.INCONSISTENT );
+  }
+
+  @Test( expected = KettleException.class )
+  public void testCheckTopLevelConsistencyNoFieldsDefined() throws KettleException {
+    List<MongoDbOutputMeta.MongoField> paths = new ArrayList<MongoDbOutputMeta.MongoField>();
+
+    MongoDbOutputData.checkTopLevelConsistency( paths, new Variables() );
+  }
 
   @Test
   public void testTopLevelObjectStructureNoNestedDocs() throws KettleException {


### PR DESCRIPTION
Backport of SP-991 (PDI-1169): MongoDB Output NPE with blank fields
