### PR TITLE
fix empty login/password

### DIFF
--- a/src/org/pentaho/mongo/wrapper/MongoClientWrapperFactory.java
+++ b/src/org/pentaho/mongo/wrapper/MongoClientWrapperFactory.java
@@ -15,10 +15,14 @@ public class MongoClientWrapperFactory {
       KerberosMongoClientWrapper wrapper = new KerberosMongoClientWrapper( meta, vars, log );
       return (MongoClientWrapper) Proxy.newProxyInstance( wrapper.getClass().getClassLoader(),
           new Class<?>[] { MongoClientWrapper.class }, new KerberosInvocationHandler( wrapper.getAuthContext(), wrapper ) );
-    } else if ( !Const.isEmpty( meta.getAuthenticationUser() ) || !Const.isEmpty( meta.getAuthenticationPassword() ) ) {
-      return new UsernamePasswordMongoClientWrapper( meta, vars, log );
     } else {
-      return new NoAuthMongoClientWrapper( meta, vars, log );
+      String user = vars.environmentSubstitute(meta.getAuthenticationUser());
+      String password = vars.environmentSubstitute(meta.getAuthenticationPassword());
+      if (!Const.isEmpty(user) || !Const.isEmpty(password)) {
+        return new UsernamePasswordMongoClientWrapper(meta, vars, log);
+      } else {
+        return new NoAuthMongoClientWrapper(meta, vars, log);
+      }
     }
   }
 }


### PR DESCRIPTION
For example, I set my login to "${myUser}" and password to "${myPassword}", and I want to use the same transformation with different databases by using those variables. One of my servers have no authorization (i.e. that parameters are empty). So, it should to use NoAuthMongoClientWrapper but instead of it, it throws exception, because empty check starts before environment substitute:

```
INFO  28-08 21:49:48,842 - My mongodb input step - Normal authentication for user 
INFO  28-08 21:49:48,855 - My mongodb input step - Configuring connection with read preference: primary
INFO  28-08 21:49:48,856 - My mongodb input step - No read preference tag sets defined
INFO  28-08 21:49:48,856 - My mongodb input step - Configuring connection with default write concern - w = 1, wTimeout: 0, journaled = false
ERROR 28-08 21:49:48,966 - My mongodb input step - There was an error connecting to MongoDB with host ****, port ****, database bla-bla-bla and collection my_collection: 
ERROR 28-08 21:49:48,966 - My mongodb input step - org.pentaho.di.core.exception.KettleException: 
com.mongodb.CommandFailureException: { "serverUsed" : "/****" , "errmsg" : "auth fails" , "ok" : 0.0}
{ "serverUsed" : "****" , "errmsg" : "auth fails" , "ok" : 0.0}

    at org.pentaho.mongo.wrapper.UsernamePasswordMongoClientWrapper.getDb(UsernamePasswordMongoClientWrapper.java:95)
    at org.pentaho.mongo.wrapper.NoAuthMongoClientWrapper.getCollection(NoAuthMongoClientWrapper.java:1104)
    at org.pentaho.di.trans.steps.mongodbinput.MongoDbInput.init(MongoDbInput.java:248)
    at org.pentaho.di.trans.step.StepInitThread.run(StepInitThread.java:62)
    at java.lang.Thread.run(Thread.java:662)
Caused by: com.mongodb.CommandFailureException: { "serverUsed" : "/****" , "errmsg" : "auth fails" , "ok" : 0.0}
    at com.mongodb.CommandResult.getException(CommandResult.java:71)
    at com.mongodb.CommandResult.throwOnError(CommandResult.java:110)
    at com.mongodb.DBPort$NativeAuthenticator.authenticate(DBPort.java:549)
    at com.mongodb.DBPort.authenticate(DBPort.java:322)
    at com.mongodb.DBTCPConnector.authenticate(DBTCPConnector.java:621)
    at com.mongodb.DBApiLayer.doAuthenticate(DBApiLayer.java:180)
    at com.mongodb.DB.authenticateCommandHelper(DB.java:630)
    at com.mongodb.DB.authenticateCommand(DB.java:609)
    at org.pentaho.mongo.wrapper.UsernamePasswordMongoClientWrapper.authenticateWithDb(UsernamePasswordMongoClientWrapper.java:101)
    at org.pentaho.mongo.wrapper.UsernamePasswordMongoClientWrapper.getDb(UsernamePasswordMongoClientWrapper.java:89)
    ... 4 more

ERROR 28-08 21:49:48,966 - My mongodb input step - Error initializing step [My mongodb input step]
```

That commit fixes that bug.
