### PR TITLE
[PDI-12944] - MongoDB Output Fix Truncate Method

### DIFF
--- a/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutput.java
+++ b/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutput.java
@@ -144,12 +144,7 @@ public class MongoDbOutput extends BaseStep implements StepInterface {
       if ( m_meta.getTruncate() ) {
         try {
           logBasic( BaseMessages.getString( PKG, "MongoDbOutput.Messages.TruncatingCollection" ) ); //$NON-NLS-1$
-          m_data.getCollection().drop();
-
-          // re-establish the collection
-          String collection = environmentSubstitute( m_meta.getCollection() );
-          m_data.createCollection( m_meta.getDbName(), collection );
-          m_data.setCollection( m_data.getConnection().getCollection( m_meta.getDbName(), collection ) );
+          m_data.getCollection().remove();
         } catch ( Exception m ) {
           disconnect();
           throw new KettleException( m.getMessage(), m );

--- a/src/org/pentaho/mongo/wrapper/collection/DefaultMongoCollectionWrapper.java
+++ b/src/org/pentaho/mongo/wrapper/collection/DefaultMongoCollectionWrapper.java
@@ -67,6 +67,16 @@ public class DefaultMongoCollectionWrapper implements MongoCollectionWrapper {
   }
 
   @Override
+  public WriteResult remove() throws KettleException {
+	return remove( new BasicDBObject() );
+  }
+
+  @Override
+  public WriteResult remove( DBObject query ) throws KettleException {
+	return collection.remove( query );
+  }
+
+  @Override
   public WriteResult save( DBObject toTry ) throws KettleException {
     return collection.save( toTry );
   }

--- a/src/org/pentaho/mongo/wrapper/collection/MongoCollectionWrapper.java
+++ b/src/org/pentaho/mongo/wrapper/collection/MongoCollectionWrapper.java
@@ -31,5 +31,9 @@ public interface MongoCollectionWrapper {
 
   void createIndex( BasicDBObject mongoIndex ) throws KettleException;
 
+  WriteResult remove() throws KettleException;
+
+  WriteResult remove( DBObject query ) throws KettleException;
+
   WriteResult save( DBObject toTry ) throws KettleException;
 }


### PR DESCRIPTION
Uses the correct "truncate" process of removing all documents from a collection, in order to preserve sharding and indexes on collection.
