### PR TITLE
PDI-13500 - MongoDB Input "GetDBs" option fails to fetch database

### DIFF
--- a/src/org/pentaho/mongo/wrapper/UsernamePasswordMongoClientWrapper.java
+++ b/src/org/pentaho/mongo/wrapper/UsernamePasswordMongoClientWrapper.java
@@ -80,7 +80,7 @@ public class UsernamePasswordMongoClientWrapper extends NoAuthMongoClientWrapper
   protected MongoCredential getCredential( MongoDbMeta meta, VariableSpace vars ) {
     String dbName = vars.environmentSubstitute( meta.getDbName() );
     dbName = dbName.trim().length() == 0 ? "admin" : dbName; 
-    return MongoCredential.createMongoCRCredential( vars.environmentSubstitute( meta.getAuthenticationUser() ), dbName,
+    return MongoCredential.createCredential( vars.environmentSubstitute( meta.getAuthenticationUser() ), dbName,
         Encr.decryptPasswordOptionallyEncrypted(
         vars.environmentSubstitute( meta.getAuthenticationPassword() ) ).toCharArray() );
   }


### PR DESCRIPTION
information when Authentication is used in MongoDB

What was done:
1) changed the method used for creating credentials