### PR TITLE
[PDI-13542] MongoDB Password Fields

### DIFF
--- a/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputDialog.java
+++ b/src/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputDialog.java
@@ -52,7 +52,6 @@ import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaFactory;
-import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.i18n.BaseMessages;
@@ -62,6 +61,7 @@ import org.pentaho.di.trans.step.StepDialogInterface;
 import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.core.dialog.ShowMessageDialog;
 import org.pentaho.di.ui.core.widget.ColumnInfo;
+import org.pentaho.di.ui.core.widget.PasswordTextVar;
 import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
@@ -298,13 +298,6 @@ public class MongoDbOutputDialog extends BaseStepDialog implements StepDialogInt
     m_usernameField = new TextVar( transMeta, wConfigComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( m_usernameField );
     m_usernameField.addModifyListener( lsMod );
-    // set the tool tip to the contents with any env variables expanded
-    m_usernameField.addModifyListener( new ModifyListener() {
-      @Override
-      public void modifyText( ModifyEvent e ) {
-        m_usernameField.setToolTipText( transMeta.environmentSubstitute( m_usernameField.getText() ) );
-      }
-    } );
     fd = new FormData();
     fd.right = new FormAttachment( 100, 0 );
     fd.top = new FormAttachment( m_useAllReplicaSetMembersBut, margin );
@@ -321,17 +314,8 @@ public class MongoDbOutputDialog extends BaseStepDialog implements StepDialogInt
     fd.right = new FormAttachment( middle, -margin );
     passLab.setLayoutData( fd );
 
-    m_passField = new TextVar( transMeta, wConfigComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
+    m_passField = new PasswordTextVar( transMeta, wConfigComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER );
     props.setLook( m_passField );
-    m_passField.setEchoChar( '*' );
-    // If the password contains a variable, don't hide it.
-    m_passField.getTextWidget().addModifyListener( new ModifyListener() {
-      @Override
-      public void modifyText( ModifyEvent e ) {
-        checkPasswordVisible();
-      }
-    } );
-
     m_passField.addModifyListener( lsMod );
 
     fd = new FormData();
@@ -1286,17 +1270,6 @@ public class MongoDbOutputDialog extends BaseStepDialog implements StepDialogInt
       m_mongoIndexesView.removeEmptyRows();
       m_mongoIndexesView.setRowNums();
       m_mongoIndexesView.optWidth( true );
-    }
-  }
-
-  private void checkPasswordVisible() {
-    String password = m_passField.getText();
-    ArrayList<String> list = new ArrayList<String>();
-    StringUtil.getUsedVariables( password, list, true );
-    if ( list.size() == 0 ) {
-      m_passField.setEchoChar( '*' );
-    } else {
-      m_passField.setEchoChar( '\0' ); // show everything
     }
   }
 

--- a/src/org/pentaho/di/ui/trans/steps/mongodbinput/MongoDbInputDialog.java
+++ b/src/org/pentaho/di/ui/trans/steps/mongodbinput/MongoDbInputDialog.java
@@ -66,6 +66,7 @@ import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.core.dialog.PreviewRowsDialog;
 import org.pentaho.di.ui.core.dialog.ShowMessageDialog;
 import org.pentaho.di.ui.core.widget.ColumnInfo;
+import org.pentaho.di.ui.core.widget.PasswordTextVar;
 import org.pentaho.di.ui.core.widget.StyledTextComp;
 import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
@@ -291,8 +292,7 @@ public class MongoDbInputDialog extends BaseStepDialog implements
     fdlAuthUser.right = new FormAttachment(middle, -margin);
     wlAuthUser.setLayoutData(fdlAuthUser);
 
-    wAuthUser = new TextVar(transMeta, wConfigComp, SWT.BORDER | SWT.READ_ONLY);
-    wAuthUser.setEditable(true);
+    wAuthUser = new TextVar(transMeta, wConfigComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
     props.setLook(wAuthUser);
     wAuthUser.addModifyListener(lsMod);
     FormData fdAuthUser = new FormData();
@@ -313,9 +313,7 @@ public class MongoDbInputDialog extends BaseStepDialog implements
     fdlAuthPass.right = new FormAttachment(middle, -margin);
     wlAuthPass.setLayoutData(fdlAuthPass);
 
-    wAuthPass = new TextVar(transMeta, wConfigComp, SWT.BORDER | SWT.READ_ONLY);
-    wAuthPass.setEditable(true);
-    wAuthPass.setEchoChar('*');
+    wAuthPass = new PasswordTextVar(transMeta, wConfigComp, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
     props.setLook(wAuthPass);
     wAuthPass.addModifyListener(lsMod);
     FormData fdAuthPass = new FormData();


### PR DESCRIPTION
Updated the Password fields to use the PasswordTextVar class in PDI.
Cleaned up some unneeded tooltip and read-only flags on the username fields.