### PR TITLE
[BACKLOG-8784] - Not correct format for osgi import-package for mongodb-plugin, fix for pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Import-Package>resolution:=optional;javax.crypto.spec*,org.eclipse.swt*;resolution:=optional,org.pentaho.di.ui.xul*;resolution:=optional,org.pentaho.ui.xul*;resolution:=optional,*</Import-Package>
+            <Import-Package>javax.crypto.spec*;resolution:=optional,org.eclipse.swt*;resolution:=optional,org.pentaho.di.ui.xul*;resolution:=optional,org.pentaho.ui.xul*;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMetaInjectionTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMetaInjectionTest.java
@@ -17,17 +17,31 @@
 
 package org.pentaho.di.trans.steps.mongodbinput;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.injection.BaseMetadataInjectionTest;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
+import org.pentaho.di.trans.steps.mongodboutput.MongoDbOutputMetaInjectionTest;
 
 /**
  * MDI test for MongoDbInput.
  */
 public class MongoDbInputMetaInjectionTest extends BaseMetadataInjectionTest<MongoDbInputMeta> {
+
+  private LogChannelInterfaceFactory oldLogChannelInterfaceFactory;
+
   @Before
   public void setup() {
+    oldLogChannelInterfaceFactory = KettleLogStore.getLogChannelInterfaceFactory();
+    MongoDbOutputMetaInjectionTest.setKettleLogFactoryWithMock();
     setup( new MongoDbInputMeta() );
+  }
+
+  @After
+  public void tearDown() {
+    KettleLogStore.setLogChannelInterfaceFactory( oldLogChannelInterfaceFactory );
   }
 
   @Test

--- a/src/test/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputMetaInjectionTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputMetaInjectionTest.java
@@ -17,18 +17,43 @@
 
 package org.pentaho.di.trans.steps.mongodboutput;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.di.core.injection.BaseMetadataInjectionTest;
-import org.pentaho.di.core.injection.BaseMetadataInjectionTest.StringGetter;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
+
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * MDI test for MongoDbOutput.
  */
 public class MongoDbOutputMetaInjectionTest extends BaseMetadataInjectionTest<MongoDbOutputMeta> {
+  private LogChannelInterfaceFactory oldLogChannelInterfaceFactory;
+
   @Before
-  public void setup() {
+  public void setup() throws IllegalAccessException {
+    oldLogChannelInterfaceFactory = KettleLogStore.getLogChannelInterfaceFactory();
+    setKettleLogFactoryWithMock();
     setup( new MongoDbOutputMeta() );
+  }
+
+  public static void setKettleLogFactoryWithMock() {
+    LogChannelInterfaceFactory logChannelInterfaceFactory = mock( LogChannelInterfaceFactory.class );
+    LogChannelInterface logChannelInterface = mock( LogChannelInterface.class );
+    when( logChannelInterfaceFactory.create( any() ) ).thenReturn(
+            logChannelInterface );
+    KettleLogStore.setLogChannelInterfaceFactory( logChannelInterfaceFactory );
+  }
+
+  @After
+  public void tearDown() {
+    KettleLogStore.setLogChannelInterfaceFactory( oldLogChannelInterfaceFactory );
   }
 
   @Test


### PR DESCRIPTION
new dependency for osgi plugin was added in commit 3fc4c8ba6315e6714d756bf04c29c5383fdeb34c
resolution:=optional,javax.crypto.spec*;
the format should be javax.crypto.spec*;resolution:=optional,
the issue comes to error while executing maven-bundle-plugin and came to error starting bundle on ce server
