### PR TITLE
[SP-2680] Backport of PDI-14736 - MongoDB Input/Output steps fail whe…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -14,4 +14,4 @@ dependency.pentaho-xul.revision=5.4-SNAPSHOT
 
 dependency.pentaho-metastore.revision=5.4-SNAPSHOT
 
-dependency.mongo-driver.revision=2.13.0
+dependency.mongo-driver.revision=2.13.3


### PR DESCRIPTION
…n Authentication is used in MongoDB (5.4 Suite)

- updated mongo-java-driver version to 2.13.3