### PR TITLE
[BACKLOG-11698] Plugin contained references to PNG when an SVG was ac…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
       <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+      <version>2.9.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMeta.java
+++ b/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMeta.java
@@ -54,7 +54,7 @@ import java.util.List;
  * @author matt
  * @since 4.2.0-M1
  */
-@Step( id = "MongoDbInput", image = "mongodb-input.png", name = "MongoDB Input",
+@Step( id = "MongoDbInput", image = "mongodb-input.svg", name = "MongoDB Input",
     description = "Reads from a Mongo DB collection", documentationUrl = "http://wiki.pentaho.com/display/EAI/MongoDB+Input", categoryDescription = "Big Data" )
 @InjectionSupported( localizationPrefix = "MongoDbInput.Injection.", groups = ( "FIELDS" ) )
 public class MongoDbInputMeta extends MongoDbMeta {

--- a/src/main/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputMeta.java
+++ b/src/main/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputMeta.java
@@ -53,7 +53,7 @@ import java.util.List;
  * 
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  */
-@Step( id = "MongoDbOutput", image = "MongoDB.png", name = "MongoDB Output",
+@Step( id = "MongoDbOutput", image = "MongoDB.svg", name = "MongoDB Output",
     description = "Writes to a Mongo DB collection", documentationUrl = "http://wiki.pentaho.com/display/EAI/MongoDB+Output", categoryDescription = "Big Data" )
 @InjectionSupported( localizationPrefix = "MongoDbOutput.Injection.", groups = { "FIELDS", "INDEXES" } )
 public class MongoDbOutputMeta extends MongoDbMeta implements StepMetaInterface {

--- a/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,7 +28,7 @@
         <property name="mainType" value="org.pentaho.di.trans.step.StepMetaInterface"/>
         <property name="name" value="MongoDB Input"/>
         <property name="ID" value="MongoDbInput"/>
-        <property name="imageFile" value="mongodb-input.png"/>
+        <property name="imageFile" value="mongodb-input.svg"/>
         <property name="description" value="Reads from a Mongo DB collection"/>
         <property name="pluginTypeInterface" value="org.pentaho.di.core.plugins.StepPluginType"/>
         <property name="category" value="Big Data"/>
@@ -51,7 +51,7 @@
         <property name="mainType" value="org.pentaho.di.trans.step.StepMetaInterface"/>
         <property name="name" value="MongoDB Output"/>
         <property name="ID" value="MongoDbOutput"/>
-        <property name="imageFile" value="MongoDB.png"/>
+        <property name="imageFile" value="MongoDB.svg"/>
         <property name="description" value="Writes to a Mongo DB collection"/>
         <property name="pluginTypeInterface" value="org.pentaho.di.core.plugins.StepPluginType"/>
         <property name="category" value="Big Data"/>


### PR DESCRIPTION
…tually being used.  Updated extension to point to actual file.  This was causing breakage in Automatic Documentation Generation

Note:  The blueprint.xml contains legacy plugin configuration.  This can be updated to use the custom pdi tag so we do not have duplicate information (blueprint & annotation).  This would be similar to Big Data Plugins.  I attempted to do this, but ran into issues with icons in the component tree.  Since code freeze is tonight I decided to change the extension in both places.  We can add a task to JIRA to clean up the plugin configuration next iteration.

@hudak / @mkambol / @mdamour1976 