### PR TITLE
[BACKLOG-21568] Updates MongoDB driver from 3.2.2 to 3.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <mockito.version>1.9.5</mockito.version>
     <junit.version>4.11</junit.version>
-    <mongo-driver.version>3.2.2</mongo-driver.version>
+    <mongo-driver.version>3.6.3</mongo-driver.version>
   </properties>
   
   <dependencies>


### PR DESCRIPTION
Related PRs:
https://github.com/pentaho/pentaho-mongodb-plugin/pull/164
https://github.com/pentaho/pentaho-mongo-utils/pull/65
https://github.com/pentaho/pdi-dataservice-server-plugin/pull/282
https://github.com/pentaho/pentaho-karaf-assembly/pull/421