### PR TITLE
[BACKLOG-22528] Changes aggregate function to use MongoDB cursors

### DIFF
--- a/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInput.java
+++ b/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInput.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 package org.pentaho.di.trans.steps.mongodbinput;
 
-import com.mongodb.AggregationOutput;
+import com.mongodb.Cursor;
 import com.mongodb.DBObject;
 import com.mongodb.ServerAddress;
 import com.mongodb.util.JSON;
@@ -188,8 +188,9 @@ public class MongoDbInput extends BaseStep implements StepInterface {
           remainder = new DBObject[0];
         }
 
-        AggregationOutput result = data.collection.aggregate( firstP, remainder );
-        data.m_pipelineResult = result.results().iterator();
+        // Utilize MongoDB cursor class
+        Cursor cursor = data.collection.aggregate( firstP, remainder );
+        data.m_pipelineResult = cursor;
       } else {
         if ( meta.getExecuteForEachIncomingRow() && m_currentInputRowDrivingQuery != null ) {
           // do field value substitution

--- a/src/main/java/org/pentaho/mongo/wrapper/field/MongodbInputDiscoverFieldsImpl.java
+++ b/src/main/java/org/pentaho/mongo/wrapper/field/MongodbInputDiscoverFieldsImpl.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@
 
 package org.pentaho.mongo.wrapper.field;
 
-import com.mongodb.AggregationOutput;
+import com.mongodb.AggregationOptions;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
+import com.mongodb.Cursor;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
@@ -447,16 +448,8 @@ public class MongodbInputDiscoverFieldsImpl implements MongoDbInputDiscoverField
 
     query = query + ", {$limit : " + numDocsToSample + "}"; //$NON-NLS-1$ //$NON-NLS-2$
     List<DBObject> samplePipe = jsonPipelineToDBObjectList( query );
-
-    DBObject first = samplePipe.get( 0 );
-    DBObject[] remainder = new DBObject[ samplePipe.size() - 1 ];
-    for ( int i = 1; i < samplePipe.size(); i++ ) {
-      remainder[ i - 1 ] = samplePipe.get( i );
-    }
-
-    AggregationOutput result = collection.aggregate( first, remainder );
-
-    return result.results().iterator();
+    Cursor cursor = collection.aggregate( samplePipe, AggregationOptions.builder().build() );
+    return cursor;
   }
 
 

--- a/src/test/java/org/pentaho/di/trans/steps/mongodbinput/BaseMongoDbStepTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mongodbinput/BaseMongoDbStepTest.java
@@ -1,7 +1,7 @@
 /*!
  * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+ * Copyright 2002 - 2018 Hitachi Vantara. All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Hitachi Vantara and its licensors. The intellectual
@@ -22,7 +22,7 @@
 
 package org.pentaho.di.trans.steps.mongodbinput;
 
-import com.mongodb.AggregationOutput;
+import com.mongodb.Cursor;
 import com.mongodb.DBObject;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -62,7 +62,7 @@ public class BaseMongoDbStepTest {
   @Mock protected MongoClientWrapper mongoClientWrapper;
   @Mock protected MongoCollectionWrapper mongoCollectionWrapper;
   @Mock protected LogChannelInterfaceFactory logChannelFactory;
-  @Mock protected AggregationOutput results;
+  @Mock protected Cursor cursor;
   @Captor protected ArgumentCaptor<String> stringCaptor;
   @Captor protected ArgumentCaptor<DBObject> dbObjectCaptor;
   @Captor protected ArgumentCaptor<Throwable> throwableCaptor;

--- a/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -116,18 +116,14 @@ public class MongoDbInputTest extends BaseMongoDbStepTest {
     DBObject[] remainder = parts.length > 1
         ? new DBObject[] { (DBObject) JSON.parse( parts[1] ) }
         : new DBObject[0];
-    when( mongoCollectionWrapper.aggregate( dbObjQuery, remainder ) ).thenReturn( results );
-    Iterable iterableResults = mock( Iterable.class );
-    Iterator resultsIterator = mock( Iterator.class );
-    when( iterableResults.iterator() ).thenReturn( resultsIterator );
-    when( results.results() ).thenReturn( iterableResults );
+    when( mongoCollectionWrapper.aggregate( dbObjQuery, remainder ) ).thenReturn( cursor );
 
     dbInput.init( stepMetaInterface, stepDataInterface );
     dbInput.processRow( stepMetaInterface, stepDataInterface );
 
     verify( stepDataInterface ).init();
     verify( mongoCollectionWrapper ).aggregate( dbObjQuery, remainder );
-    assertEquals( stepDataInterface.m_pipelineResult, resultsIterator );
+    assertEquals( cursor, stepDataInterface.m_pipelineResult );
   }
 
   @Test public void testSimpleFind() throws KettleException, MongoDbException {

--- a/src/test/java/org/pentaho/mongo/wrapper/field/MongodbInputDiscoverFieldsImplTest.java
+++ b/src/test/java/org/pentaho/mongo/wrapper/field/MongodbInputDiscoverFieldsImplTest.java
@@ -1,7 +1,7 @@
 /*!
  * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
  *
- * Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+ * Copyright 2002 - 2018 Hitachi Vantara. All rights reserved.
  *
  * NOTICE: All information including source code contained herein is, and
  * remains the sole property of Hitachi Vantara and its licensors. The intellectual
@@ -22,7 +22,7 @@
 
 package org.pentaho.mongo.wrapper.field;
 
-import com.mongodb.AggregationOutput;
+import com.mongodb.AggregationOptions;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
@@ -55,7 +55,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -179,21 +178,24 @@ public class MongodbInputDiscoverFieldsImplTest {
   @Test public void testPipelineQueryIsLimited() throws KettleException, MongoDbException {
     setupPerform();
 
-    AggregationOutput aggOutput = mock( AggregationOutput.class );
-    Iterable<DBObject> results = mock( Iterable.class );
-    when( aggOutput.results() ).thenReturn( results );
-    when( results.iterator() ).thenReturn( mock( Iterator.class ) );
-
     String query = "{$sort : 1}";
+
+    // Setup DBObjects collection
+    List<DBObject> dbObjects = new ArrayList<DBObject>();
     DBObject firstOp = (DBObject) JSON.parse( query );
     DBObject[] remainder = { new BasicDBObject( "$limit", NUM_DOCS_TO_SAMPLE ) };
-    when( collection.aggregate( firstOp, remainder ) )
-        .thenReturn( aggOutput );
+    dbObjects.add( firstOp );
+    Collections.addAll( dbObjects, remainder );
+    AggregationOptions options = AggregationOptions.builder().build();
+
+    //when( MongodbInputDiscoverFieldsImpl.jsonPipelineToDBObjectList( query ) ).thenReturn( dbObjects );
+    when( collection.aggregate( anyList(), any( AggregationOptions.class ) ) )
+        .thenReturn( cursor );
 
     discoverFields.discoverFields( new MongoProperties.Builder(), "mydb", "mycollection", query, "", true,
         NUM_DOCS_TO_SAMPLE, inputMeta );
 
-    verify( collection ).aggregate( firstOp, remainder );
+    verify( collection ).aggregate( anyList(), any( AggregationOptions.class ) );
   }
 
   @Test ( expected = KettleException.class )


### PR DESCRIPTION
Fixed issue with pentaho-mongo-utils, this 'should' be good to go now.

Needs to be merged with https://github.com/pentaho/pentaho-mongo-utils/pull/68