### PR TITLE
MongoDB Input Step aggregation framework disk usage

### DIFF
--- a/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInput.java
+++ b/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInput.java
@@ -189,7 +189,13 @@ public class MongoDbInput extends BaseStep implements StepInterface {
         }
 
         // Utilize MongoDB cursor class
-        Cursor cursor = data.collection.aggregate( firstP, remainder );
+        Cursor cursor;
+        if (meta.getAggregationAllowDisk()) {
+        	cursor = data.collection.aggregate( firstP, remainder, meta.getAggregationAllowDisk() );
+        } else {
+        	cursor = data.collection.aggregate( firstP, remainder );
+        }
+        
         data.m_pipelineResult = cursor;
       } else {
         if ( meta.getExecuteForEachIncomingRow() && m_currentInputRowDrivingQuery != null ) {

--- a/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMeta.java
+++ b/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMeta.java
@@ -73,6 +73,9 @@ public class MongoDbInputMeta extends MongoDbMeta {
 
   @Injection( name = "AGG_PIPELINE" )
   private boolean m_aggPipeline = false;
+  
+  @Injection( name = "AGG_ALLOW_DISK" )
+  private boolean m_agg_allow_disk = false;
 
   @Injection( name = "OUTPUT_JSON" )
   private boolean m_outputJson = true;
@@ -153,6 +156,11 @@ public class MongoDbInputMeta extends MongoDbMeta {
       String queryIsPipe = XMLHandler.getTagValue( stepnode, "query_is_pipeline" ); //$NON-NLS-1$
       if ( !Const.isEmpty( queryIsPipe ) ) {
         m_aggPipeline = queryIsPipe.equalsIgnoreCase( "Y" ); //$NON-NLS-1$
+      }
+      
+      String aggAllowDisk = XMLHandler.getTagValue( stepnode, "agg_allow_disk" ); //$NON-NLS-1$
+      if ( !Const.isEmpty( aggAllowDisk ) ) {
+        m_agg_allow_disk = aggAllowDisk.equalsIgnoreCase( "Y" ); //$NON-NLS-1$
       }
 
       String executeForEachR = XMLHandler.getTagValue( stepnode, "execute_for_each_row" );
@@ -285,6 +293,8 @@ public class MongoDbInputMeta extends MongoDbMeta {
         XMLHandler.addTagValue( "output_json", m_outputJson ) ); //$NON-NLS-1$
     retval.append( "    " ).append( //$NON-NLS-1$
         XMLHandler.addTagValue( "query_is_pipeline", m_aggPipeline ) ); //$NON-NLS-1$
+    retval.append( "    " ).append(
+    		XMLHandler.addTagValue("agg_allow_disk", m_agg_allow_disk));
     retval.append( "    " ).append( //$NON-NLS-1$
         XMLHandler.addTagValue( "execute_for_each_row", m_executeForEachIncomingRow ) ); //$NON-NLS-1$
 
@@ -344,6 +354,7 @@ public class MongoDbInputMeta extends MongoDbMeta {
 
       m_outputJson = rep.getStepAttributeBoolean( id_step, 0, "output_json" ); //$NON-NLS-1$
       m_aggPipeline = rep.getStepAttributeBoolean( id_step, "query_is_pipeline" ); //$NON-NLS-1$
+      m_agg_allow_disk = rep.getStepAttributeBoolean(id_step, "agg_allow_disk");
       m_executeForEachIncomingRow = rep.getStepAttributeBoolean( id_step, "execute_for_each_row" ); //$NON-NLS-1$
 
       int nrfields = rep.countNrStepAttributes( id_step, "field_name" ); //$NON-NLS-1$
@@ -409,6 +420,8 @@ public class MongoDbInputMeta extends MongoDbMeta {
           m_outputJson );
       rep.saveStepAttribute( id_transformation, id_step, 0, "query_is_pipeline", //$NON-NLS-1$
           m_aggPipeline );
+      rep.saveStepAttribute( id_transformation, id_step, "agg_allow_disk", 
+    	  m_agg_allow_disk );
       rep.saveStepAttribute( id_transformation, id_step, 0, "execute_for_each_row", //$NON-NLS-1$
           m_executeForEachIncomingRow );
 
@@ -537,5 +550,13 @@ public class MongoDbInputMeta extends MongoDbMeta {
    */
   public boolean getQueryIsPipeline() {
     return m_aggPipeline;
+  }
+  
+  public void setAggegationAllowDisk(boolean q) {
+    m_agg_allow_disk = q;
+  }
+  
+  public boolean getAggregationAllowDisk() {
+	return m_agg_allow_disk;
   }
 }

--- a/src/main/java/org/pentaho/di/ui/trans/steps/mongodbinput/MongoDbInputDialog.java
+++ b/src/main/java/org/pentaho/di/ui/trans/steps/mongodbinput/MongoDbInputDialog.java
@@ -112,6 +112,7 @@ public class MongoDbInputDialog extends BaseStepDialog implements StepDialogInte
   private StyledTextComp wJsonQuery;
   private Label wlJsonQuery;
   private Button m_queryIsPipelineBut;
+  private Button m_aggAllowDiskBut;
 
   private TextVar wAuthDbName;
   private TextVar wAuthUser;
@@ -865,6 +866,15 @@ public class MongoDbInputDialog extends BaseStepDialog implements StepDialogInte
         updateQueryTitleInfo();
       }
     } );
+    
+    m_aggAllowDiskBut = new Button(wQueryComp, SWT.CHECK);
+    props.setLook(m_aggAllowDiskBut);
+    fd = new FormData();
+    fd.bottom = new FormAttachment(lastControl, -margin);
+    fd.right = new FormAttachment(middle, 0);
+    fd.left = new FormAttachment(100, 0);
+    m_aggAllowDiskBut.setLayoutData(fd);
+    lastControl = m_aggAllowDiskBut;
 
     // JSON Query input ...
     //
@@ -1119,6 +1129,7 @@ public class MongoDbInputDialog extends BaseStepDialog implements StepDialogInte
     m_useSSLSocketFactory.setSelection( meta.isUseSSLSocketFactory() );
     m_readPreference.setText( Const.NVL( meta.getReadPreference(), "" ) ); //$NON-NLS-1$
     m_queryIsPipelineBut.setSelection( meta.getQueryIsPipeline() );
+    m_aggAllowDiskBut.setSelection( meta.getAggregationAllowDisk() );
     m_outputAsJson.setSelection( meta.getOutputJson() );
     m_executeForEachRowBut.setSelection( meta.getExecuteForEachIncomingRow() );
 
@@ -1139,9 +1150,11 @@ public class MongoDbInputDialog extends BaseStepDialog implements StepDialogInte
           + ": db." //$NON-NLS-1$
           + Const.NVL( wCollection.getText(), "n/a" ) + ".aggregate(..." ); //$NON-NLS-1$ //$NON-NLS-2$
       wFieldsName.setEnabled( false );
+      m_aggAllowDiskBut.setEnabled(true);
     } else {
       wlJsonQuery.setText( BaseMessages.getString( PKG, "MongoDbInputDialog.JsonQuery.Label" ) ); //$NON-NLS-1$
       wFieldsName.setEnabled( true );
+      m_aggAllowDiskBut.setEnabled(false);
     }
   }
 
@@ -1173,6 +1186,7 @@ public class MongoDbInputDialog extends BaseStepDialog implements StepDialogInte
     meta.setReadPreference( m_readPreference.getText() );
     meta.setOutputJson( m_outputAsJson.getSelection() );
     meta.setQueryIsPipeline( m_queryIsPipelineBut.getSelection() );
+    meta.setAggegationAllowDisk( m_aggAllowDiskBut.getSelection() );
     meta.setExecuteForEachIncomingRow( m_executeForEachRowBut.getSelection() );
 
     int numNonEmpty = m_fieldsView.nrNonEmpty();

--- a/src/main/java/org/pentaho/di/ui/trans/steps/mongodbinput/MongoDbInputDialog.java
+++ b/src/main/java/org/pentaho/di/ui/trans/steps/mongodbinput/MongoDbInputDialog.java
@@ -867,6 +867,15 @@ public class MongoDbInputDialog extends BaseStepDialog implements StepDialogInte
       }
     } );
     
+    Label aggAllowDiskL = new Label(wQueryComp, SWT.RIGHT);
+    aggAllowDiskL.setText( BaseMessages.getString(PKG, "MongoDbInputDialog.AllowDiskUsage.Label"));
+    props.setLook( aggAllowDiskL );
+    fd = new FormData();
+    fd.bottom = new FormAttachment(lastControl, -margin);
+    fd.left = new FormAttachment(0, -margin);
+    fd.right = new FormAttachment(middle, -margin);
+    aggAllowDiskL.setLayoutData(aggAllowDiskL);
+    
     m_aggAllowDiskBut = new Button(wQueryComp, SWT.CHECK);
     props.setLook(m_aggAllowDiskBut);
     fd = new FormData();

--- a/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMetaInjectionTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputMetaInjectionTest.java
@@ -141,6 +141,11 @@ public class MongoDbInputMetaInjectionTest extends BaseMetadataInjectionTest<Mon
         return meta.getQueryIsPipeline();
       }
     } );
+    check( "AGG_ALLOW_DISK" , new BooleanGetter() {
+    	public boolean get() {
+    		return meta.getAggregationAllowDisk();
+    	}
+    });
     check( "OUTPUT_JSON", new BooleanGetter() {
       public boolean get() {
         return meta.getOutputJson();


### PR DESCRIPTION
Including code that allows MongoDB Input Step aggregation framework query to use disk. It's required for pipelines with large collections

Also check on pentaho-mongo-utils pull request that enables this feature.
[#70](https://github.com/pentaho/pentaho-mongo-utils/pull/70)