### PR TITLE
[PDI-18180] Upgrade mongodb java driver for eventual support of Mongo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <mockito.version>1.9.5</mockito.version>
     <junit.version>4.11</junit.version>
-    <mongo-driver.version>3.6.3</mongo-driver.version>
+    <mongo-driver.version>3.10.2</mongo-driver.version>
   </properties>
   
   <dependencies>

--- a/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInput.java
+++ b/src/main/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInput.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class MongoDbInput extends BaseStep implements StepInterface {
         }
 
         if ( meta.getOutputJson() || meta.getMongoFields() == null || meta.getMongoFields().size() == 0 ) {
-          String json = nextDoc.toString();
+          String json = JSON.serialize( nextDoc );
           row = RowDataUtil.allocateRowData( data.outputRowMeta.size() );
           int index = 0;
 

--- a/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mongodbinput/MongoDbInputTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2018 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,8 +29,6 @@ import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.mongo.MongoDbException;
 import org.pentaho.mongo.wrapper.cursor.MongoCursorWrapper;
-
-import java.util.Iterator;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
@@ -171,7 +169,7 @@ public class MongoDbInputTest extends BaseMongoDbStepTest {
     verify( mockLog ).logBasic( stringCaptor.capture() );
     assertThat( stringCaptor.getValue(), containsString( "serveraddress" ) );
     assertThat( stepDataInterface.cursor, equalTo( mockCursor ) );
-    assertThat( putRow[0], CoreMatchers.<Object>equalTo( nextDoc.toString() ) );
+    assertThat( putRow[0], CoreMatchers.<Object>equalTo( JSON.serialize( nextDoc ) ) );
   }
 
   @Test public void testFindWithQuery() throws KettleException, MongoDbException {

--- a/src/test/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputTest.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputTest.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.WriteResult;
 import junit.framework.Assert;
+import com.mongodb.util.JSON;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
@@ -176,7 +177,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.RECORD, false );
 
-    assertEquals( result.toString(), "{ \"field1\" : \"value1\" , \"field2\" : 12}" );
+    assertEquals( JSON.serialize( result ), "{ \"field1\" : \"value1\" , \"field2\" : 12}" );
   }
 
   /**
@@ -220,7 +221,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.RECORD, false );
 
     // here we expect that field1 does *not* occur twice in the update object
-    assertEquals( result.toString(), "{ \"field1\" : \"value1\" , \"field2\" : 12}" );
+    assertEquals( JSON.serialize( result ), "{ \"field1\" : \"value1\" , \"field2\" : 12}" );
   }
 
   @Test public void testTopLevelObjectStructureNoNestedDocs() throws Exception {
@@ -241,8 +242,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.RECORD, false );
 
-    assertEquals( result.toString(), "{ \"field1\" : \"value1\" , \"field2\" : 12}" );
-
+    assertEquals( JSON.serialize( result ), "{ \"field1\" : \"value1\" , \"field2\" : 12}" );
   }
 
   @Test public void testTopLevelArrayStructureWithPrimitives() throws Exception {
@@ -263,7 +263,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.ARRAY, false );
 
-    assertEquals( result.toString(), "[ \"value1\" , 12]" );
+    assertEquals( JSON.serialize( result ), "[ \"value1\" , 12]" );
   }
 
   @Test public void testTopLevelArrayStructureWithObjects() throws Exception {
@@ -284,7 +284,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.ARRAY, false );
 
-    assertEquals( result.toString(), "[ { \"field1\" : \"value1\"} , { \"field2\" : 12}]" );
+    assertEquals( JSON.serialize( result ), "[ { \"field1\" : \"value1\"} , { \"field2\" : 12}]" );
   }
 
   @Test public void testTopLevelArrayStructureContainingOneObjectMutipleFields() throws Exception {
@@ -305,7 +305,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.ARRAY, false );
 
-    assertEquals( result.toString(), "[ { \"field1\" : \"value1\" , \"field2\" : 12}]" );
+    assertEquals( JSON.serialize( result ), "[ { \"field1\" : \"value1\" , \"field2\" : 12}]" );
   }
 
   @Test public void testTopLevelArrayStructureContainingObjectWithArray() throws Exception {
@@ -338,7 +338,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.ARRAY, false );
 
-    assertEquals( result.toString(), "[ { \"inner\" : [ { \"field1\" : \"value1\"} , { \"field2\" : 12}]}]" );
+    assertEquals( JSON.serialize( result ), "[ { \"inner\" : [ { \"field1\" : \"value1\"} , { \"field2\" : 12}]}]" );
   }
 
   @Test public void testTopLevelObjectStructureOneLevelNestedDoc() throws Exception {
@@ -359,7 +359,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.RECORD, false );
 
-    assertEquals( result.toString(), "{ \"field1\" : \"value1\" , \"nestedDoc\" : { \"field2\" : 12}}" );
+    assertEquals( JSON.serialize( result ), "{ \"field1\" : \"value1\" , \"nestedDoc\" : { \"field2\" : 12}}" );
   }
 
   @Test public void testTopLevelObjectStructureTwoLevelNested() throws Exception {
@@ -392,7 +392,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.RECORD, false );
 
-    assertEquals( result.toString(),
+    assertEquals( JSON.serialize( result ),
       "{ \"nestedDoc\" : { \"secondNested\" : { \"field1\" : \"value1\"} , \"field2\" : 12}}" );
   }
 
@@ -467,7 +467,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
     assertEquals( setOpp.keySet().size(), 1 );
 
     // check the resulting update structure
-    assertEquals( modifierUpdate.toString(),
+    assertEquals( JSON.serialize( modifierUpdate ),
       "{ \"$set\" : { \"bob.fred\" : [ { \"george\" : { \"field1\" : \"value1\" , \"field2\" : \"value2\"}}]}}" );
   }
 
@@ -507,7 +507,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
     // to the end of the array
     assertEquals( setOpp.keySet().size(), 1 );
 
-    assertEquals( modifierUpdate.toString(),
+    assertEquals( JSON.serialize( modifierUpdate ),
       "{ \"$push\" : { \"bob.fred\" : { \"george\" : { \"field1\" : \"value1\" , \"field2\" : \"value2\"}}}}" );
   }
 
@@ -554,7 +554,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
     // to the end of the array
     assertEquals( setOpp.keySet().size(), 1 );
 
-    assertEquals( modifierUpdate.toString(),
+    assertEquals( JSON.serialize( modifierUpdate ),
       "{ \"$push\" : { \"bob.fred\" : { \"george\" : { \"field1\" : \"value1\" , \"field2\" : \"value2\" , "
         + "\"jsonField\" : "
         + "{ \"jsonDocField1\" : \"aval\" , \"jsonDocField2\" : 42}}}}}" );
@@ -590,7 +590,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rm, row, vs, MongoDbOutputData.MongoTopLevel.RECORD, false );
 
-    assertEquals( result.toString(),
+    assertEquals( JSON.serialize( result ),
       "{ \"field1\" : \"value1\" , \"field2\" : 12 , \"jsonField\" : { \"jsonDocField1\" : \"aval\" , "
         + "\"jsonDocField2\" : 42}}" );
 
@@ -667,7 +667,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.RECORD, false );
 
-    assertEquals( result.toString(),
+    assertEquals( JSON.serialize( result ),
       "{ \"field1\" : \"value1\" , \"nestedDoc\" : { \"field2\" : 12 , \"jsonField\" : { \"jsonDocField1\" : \"aval\""
         + " , \"jsonDocField2\" : 42}}}" );
   }
@@ -702,7 +702,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject result = kettleRowToMongo( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.ARRAY, false );
 
-    assertEquals( result.toString(),
+    assertEquals( JSON.serialize( result ),
       "[ { \"field1\" : \"value1\"} , { \"field2\" : 12} , { \"jsonDocField1\" : \"aval\" , \"jsonDocField2\" : 42}]" );
 
   }
@@ -740,7 +740,7 @@ public class MongoDbOutputTest extends BaseMongoDbStepTest {
 
     DBObject query = MongoDbOutputData.getQueryObject( paths, rmi, row, vs, MongoDbOutputData.MongoTopLevel.RECORD );
 
-    assertEquals( query.toString(),
+    assertEquals( JSON.serialize( query ),
       "{ \"field1\" : \"value1\" , \"field2\" : 12 , \"jsonField\" : { \"jsonDocField1\" : \"aval\" , "
         + "\"jsonDocField2\" : 42}}" );
   }


### PR DESCRIPTION
…DB4.x

- Update pom to use mongo-java-driver version 3.10.2
- Update based on driver class change to use JSON.serialize instead of tostring to maintain expected behavior.