### PR TITLE
[PDI-16248]Add support for Int32 datatype for MongoDB Input and Output

### DIFF
--- a/pentaho-mongodb-plugin/src/main/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputData.java
+++ b/pentaho-mongodb-plugin/src/main/java/org/pentaho/di/trans/steps/mongodboutput/MongoDbOutputData.java
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2010 - 2020 Hitachi Vantara.  All rights reserved.
+ * Copyright 2010 - 2024 Hitachi Vantara.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -822,7 +822,11 @@ public class MongoDbOutputData extends BaseStepData implements StepDataInterface
     }
     if ( kettleType.isInteger() ) {
       Long val = kettleType.getInteger( kettleValue );
-      mongoObject.put( lookup.toString(), val.longValue() );
+      if(val > Integer.MAX_VALUE || val < Integer.MIN_VALUE) {
+        mongoObject.put(lookup.toString(), val.longValue());
+      } else {
+        mongoObject.put(lookup.toString(),val.intValue());
+      }
       return true;
     }
     if ( kettleType.isDate() ) {


### PR DESCRIPTION
[PDI-16248] Add support for Int32 datatype for MongoDB Input and Output

[PDI-16248]: https://hv-eng.atlassian.net/browse/PDI-16248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ