### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/pentaho-mongodb-plugin/pom.xml
+++ b/pentaho-mongodb-plugin/pom.xml
@@ -32,7 +32,6 @@
 
   <properties>
     <mockito.version>5.10.0</mockito.version>
-    <byte-buddy.version>1.12.16</byte-buddy.version>
     <junit.version>4.13.2</junit.version>
     <mongo-driver.version>3.12.10</mongo-driver.version>
     <platform.version>11.0.0.0-SNAPSHOT</platform.version>


### PR DESCRIPTION
This pull request makes a minor update by removing the `byte-buddy.version` property from the `pom.xml` file, likely as part of a dependency cleanup.